### PR TITLE
Add default value to Game.confidential property

### DIFF
--- a/grails-app/domain/ru/srms/larp/platform/game/Game.groovy
+++ b/grails-app/domain/ru/srms/larp/platform/game/Game.groovy
@@ -11,7 +11,7 @@ class Game implements Titled, Wrapped<Game>, InGameStuff {
   String preview
   String overview
   Boolean active = false
-  Boolean confidential
+  Boolean confidential = false
 
   transient int previewPureLength
   static hasMany = [


### PR DESCRIPTION
 App can't start in "create-drop" db-mode, cause "confidential"
 property has no default value, and property is not set
 in Bootstrap.groovy. So it's better to add default value.
