### PR TITLE
Increase max length of database fields

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -68,7 +68,7 @@ grails.project.dependency.resolution = {
     runtime(':hibernate4:4.3.10') {
       excludes "ehcache-core"
     }
-    runtime ':database-migration:1.4.0'
+    runtime ':database-migration:1.4.1'
 
     // plugins for the compile step
     compile ':cache:1.1.8'

--- a/grails-app/domain/ru/srms/larp/platform/game/character/request/RequestFormField.groovy
+++ b/grails-app/domain/ru/srms/larp/platform/game/character/request/RequestFormField.groovy
@@ -17,8 +17,8 @@ class RequestFormField implements InGameStuff {
   static hasMany = [values: FormFieldValue]
 
   static constraints = {
-    title maxSize: 32
-    hint nullable: true, maxSize: 128
+    title maxSize: 300
+    hint nullable: true, maxSize: 300
     data nullable: true, maxSize: 512
   }
 

--- a/grails-app/migrations/gorm.updates.2.changelog.xml
+++ b/grails-app/migrations/gorm.updates.2.changelog.xml
@@ -76,4 +76,9 @@
     <changeSet author="Treble Snake" id="1474223763022-18">
         <dropIndex indexName="unique_character_name" tableName="game_character"/>
     </changeSet>
+
+    <changeSet author="Treble Snake" id="14742313723583-1">
+        <modifyDataType columnName="title" newDataType="varchar(300)" tableName="character_request_form_field"/>
+        <modifyDataType columnName="hint" newDataType="varchar(300)" tableName="character_request_form_field"/>
+    </changeSet>
 </databaseChangeLog>

--- a/grails-app/views/characterRequestField/_form.gsp
+++ b/grails-app/views/characterRequestField/_form.gsp
@@ -3,7 +3,7 @@
 <div class="${hasErrors(bean: subject, field: 'title', 'error')} required field">
   <label for="title">Название:</label>
   <g:textField name="title" required="" value="${subject?.title}"/>
-  <div class="ui pointing label">Максимум 32 символа.</div>
+  <div class="ui pointing label">Максимум 300 символов.</div>
 </div>
 
 <div class="${hasErrors(bean: subject, field: 'type', 'error')} required field">
@@ -23,7 +23,7 @@
 <div class="${hasErrors(bean: subject, field: 'hint', 'error')} field">
   <label for="hint">Подсказка:</label>
   <g:textField name="hint" value="${subject?.hint}"/>
-  <div class="ui pointing label">Подсказка для поля, как вот эта. Максимум 128 символов.</div>
+  <div class="ui pointing label">Подсказка для поля, как вот эта. Максимум 300 символов.</div>
 </div>
 
 <div class="${hasErrors(bean: subject, field: 'required', 'error')} field">


### PR DESCRIPTION
Increase max length of database fields
Set max length of Character Requests' form field to 300.

Update database migration plugin version
